### PR TITLE
Added button to import charts from Topsters 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   "dependencies": {
     "bootstrap-icons-vue": "^0.7.0",
     "core-js": "^3.6.5",
+    "pako": "^2.0.4",
     "topster": "^5.3.0",
     "vue": "^3.0.0",
     "vuex": "^4.0.2"
   },
   "devDependencies": {
+    "@types/pako": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^4.18.0",
     "@typescript-eslint/parser": "^4.18.0",
     "@vue/cli-plugin-babel": "~4.5.0",

--- a/src/components/ChartBuilder/TopBar.vue
+++ b/src/components/ChartBuilder/TopBar.vue
@@ -12,17 +12,6 @@
       >
         +
       </button>
-      <button
-        @click="importTopsters2Charts"
-      >
-        Import from Topsters 2
-      </button>
-      <input
-        type="file"
-        style="display: none"
-        ref="importTopsters2"
-        accept="application/json"
-        @change="importTopsters2ChartsPicked"/>
     </div>
     <button
       v-if="!loading"
@@ -49,9 +38,8 @@ import { initialState, State } from '../../store'
 import { BIconFileEarmarkArrowDown, BIconArrowRepeat } from 'bootstrap-icons-vue'
 import Switcher from './Switcher.vue'
 import { getStoredCharts, setStoredCharts } from '../../helpers/localStorage'
-import { BackgroundTypes, StoredChart, ChartItem } from '@/types'
+import { StoredChart } from '@/types'
 import { addImgElements, downloadChart, initializeFirstRun } from '@/helpers/chart'
-import pako from 'pako'
 
 export default defineComponent({
   components: {
@@ -113,146 +101,6 @@ export default defineComponent({
         addImgElements(newStoredCharts[0].data)
         this.$store.commit('setEntireChart', newStoredCharts[0].data)
       }
-    },
-    importTopsters2Charts () {
-      (this.$refs.importTopsters2 as HTMLFormElement).click()
-    },
-    importTopsters2ChartsPicked (event: Event) {
-      if (event.target === null) return
-      const files = (event.target as HTMLInputElement).files
-      if (files === null) return
-      const fileReader = new FileReader()
-      fileReader.addEventListener('load', () => {
-        try {
-          // Parse JSON file
-          const charts = JSON.parse(fileReader.result as string)[0]
-          const options = JSON.parse(charts.options)
-
-          // Import each chart
-          const textDecoder = new TextDecoder()
-          const storedCharts = getStoredCharts()
-          const failed = []
-          for (const chart of Object.entries(options.charts)) {
-            let prefix = chart[0] + '-'
-            if (prefix === 'cards-') prefix = ''
-            const name = chart[1] as string
-
-            try {
-              const custom = JSON.parse(charts[prefix + 'custom'])
-              const size = charts[prefix + 'size']
-              const chartSize = { x: 3, y: 3 }
-              switch (size) {
-                case '25': // Collage
-                  chartSize.x = custom.columns
-                  chartSize.y = custom.rows
-                  break
-                case '40': // Top 40
-                  chartSize.x = 5
-                  chartSize.y = 8
-                  break
-                case '42': // Top 42
-                  chartSize.x = 6
-                  chartSize.y = 7
-                  break
-                case '100': // Top 100
-                  chartSize.x = 10
-                  chartSize.y = 10
-                  break
-                default: // This should not happen, but set it to the max size just in case
-                  chartSize.x = 12
-                  chartSize.y = 12
-                  break
-              }
-
-              // Get background and parse if it's an image
-              let background = charts[prefix + 'background']
-              let backgroundImg = null
-              if (!background.startsWith('#')) {
-                try {
-                  // Parse URL
-                  const imgURL = background.match(/url\("(.+?)"\)/)
-                  if (imgURL === null) throw new Error()
-                  background = imgURL[1]
-                  backgroundImg = new Image()
-                  backgroundImg.src = background
-                } catch (e) {
-                  // Invalid URL format, set background color to black as fallback
-                  background = '#000000'
-                }
-              }
-
-              // Chart cards are compressed with zlib + encoded with base64
-              const chartCards = charts[prefix + 'cards'] // Get base64 string
-              const cardsCompressed = Uint8Array.from(atob(chartCards.substring(1, chartCards.length - 1)), c => c.charCodeAt(0)) // Convert base64 to bytes
-              const cardsDecompressed = textDecoder.decode(pako.inflate(cardsCompressed)) // Decompress and convert to text
-              const cards = JSON.parse(cardsDecompressed) // Parse cards
-
-              // Create chart items
-              const items: Array<ChartItem | null> = []
-              for (const card of cards) {
-                // Empty card
-                if (card.src === '') {
-                  items.push(null)
-                  continue
-                }
-
-                // Create item image
-                const img = new Image()
-                img.src = card.src
-
-                // Create item
-                const item: ChartItem = {
-                  title: card.title,
-                  coverURL: card.src,
-                  coverImg: img
-                }
-                items.push(item)
-              }
-
-              // Create new chart
-              const newChart: StoredChart = {
-                timestamp: new Date().getTime(),
-                name: name,
-                data: {
-                  title: '',
-                  items: items,
-                  size: chartSize,
-                  background: {
-                    type: background.startsWith('#') ? BackgroundTypes.Color : BackgroundTypes.Image,
-                    value: background,
-                    img: backgroundImg
-                  },
-                  shadows: custom.shadowed,
-                  showNumbers: charts[prefix + 'numbered'] === 'true',
-                  showTitles: charts[prefix + 'titled'] === 'true',
-                  gap: custom.padding * 5,
-                  font: custom.fontFamily
-                },
-                currentlyActive: false
-              }
-
-              storedCharts.push(newChart)
-            } catch (e) {
-              console.error(e)
-              failed.push(name)
-            }
-          }
-
-          if (failed.length > 0) {
-            alert('Failed to import the following charts: ' + failed.join(', '))
-          } else {
-            alert('Charts imported successfully!')
-          }
-
-          setStoredCharts(storedCharts)
-          this.$store.commit('setEntireChart', storedCharts.filter((chart) => chart.currentlyActive)[0].data) // Force update, possibly a better way of doing this?
-        } catch (e) {
-          console.error(e)
-          alert('The file selected is not a valid Topsters 2 backup: ' + e)
-        }
-      })
-
-      fileReader.readAsText(files[0])
     }
   },
   computed: mapState({

--- a/src/components/ChartBuilder/TopBar.vue
+++ b/src/components/ChartBuilder/TopBar.vue
@@ -12,6 +12,17 @@
       >
         +
       </button>
+      <button
+        @click="importTopsters2Charts"
+      >
+        Import from Topsters 2
+      </button>
+      <input
+        type="file"
+        style="display: none"
+        ref="importTopsters2"
+        accept="application/json"
+        @change="importTopsters2ChartsPicked"/>
     </div>
     <button
       v-if="!loading"
@@ -38,8 +49,9 @@ import { initialState, State } from '../../store'
 import { BIconFileEarmarkArrowDown, BIconArrowRepeat } from 'bootstrap-icons-vue'
 import Switcher from './Switcher.vue'
 import { getStoredCharts, setStoredCharts } from '../../helpers/localStorage'
-import { StoredChart } from '@/types'
+import { BackgroundTypes, StoredChart, ChartItem } from '@/types'
 import { addImgElements, downloadChart, initializeFirstRun } from '@/helpers/chart'
+import pako from 'pako'
 
 export default defineComponent({
   components: {
@@ -101,6 +113,146 @@ export default defineComponent({
         addImgElements(newStoredCharts[0].data)
         this.$store.commit('setEntireChart', newStoredCharts[0].data)
       }
+    },
+    importTopsters2Charts () {
+      (this.$refs.importTopsters2 as HTMLFormElement).click()
+    },
+    importTopsters2ChartsPicked (event: Event) {
+      if (event.target === null) return
+      const files = (event.target as HTMLInputElement).files
+      if (files === null) return
+      const fileReader = new FileReader()
+      fileReader.addEventListener('load', () => {
+        try {
+          // Parse JSON file
+          const charts = JSON.parse(fileReader.result as string)[0]
+          const options = JSON.parse(charts.options)
+
+          // Import each chart
+          const textDecoder = new TextDecoder()
+          const storedCharts = getStoredCharts()
+          const failed = []
+          for (const chart of Object.entries(options.charts)) {
+            let prefix = chart[0] + '-'
+            if (prefix === 'cards-') prefix = ''
+            const name = chart[1] as string
+
+            try {
+              const custom = JSON.parse(charts[prefix + 'custom'])
+              const size = charts[prefix + 'size']
+              const chartSize = { x: 3, y: 3 }
+              switch (size) {
+                case '25': // Collage
+                  chartSize.x = custom.columns
+                  chartSize.y = custom.rows
+                  break
+                case '40': // Top 40
+                  chartSize.x = 5
+                  chartSize.y = 8
+                  break
+                case '42': // Top 42
+                  chartSize.x = 6
+                  chartSize.y = 7
+                  break
+                case '100': // Top 100
+                  chartSize.x = 10
+                  chartSize.y = 10
+                  break
+                default: // This should not happen, but set it to the max size just in case
+                  chartSize.x = 12
+                  chartSize.y = 12
+                  break
+              }
+
+              // Get background and parse if it's an image
+              let background = charts[prefix + 'background']
+              let backgroundImg = null
+              if (!background.startsWith('#')) {
+                try {
+                  // Parse URL
+                  const imgURL = background.match(/url\("(.+?)"\)/)
+                  if (imgURL === null) throw new Error()
+                  background = imgURL[1]
+                  backgroundImg = new Image()
+                  backgroundImg.src = background
+                } catch (e) {
+                  // Invalid URL format, set background color to black as fallback
+                  background = '#000000'
+                }
+              }
+
+              // Chart cards are compressed with zlib + encoded with base64
+              const chartCards = charts[prefix + 'cards'] // Get base64 string
+              const cardsCompressed = Uint8Array.from(atob(chartCards.substring(1, chartCards.length - 1)), c => c.charCodeAt(0)) // Convert base64 to bytes
+              const cardsDecompressed = textDecoder.decode(pako.inflate(cardsCompressed)) // Decompress and convert to text
+              const cards = JSON.parse(cardsDecompressed) // Parse cards
+
+              // Create chart items
+              const items: Array<ChartItem | null> = []
+              for (const card of cards) {
+                // Empty card
+                if (card.src === '') {
+                  items.push(null)
+                  continue
+                }
+
+                // Create item image
+                const img = new Image()
+                img.src = card.src
+
+                // Create item
+                const item: ChartItem = {
+                  title: card.title,
+                  coverURL: card.src,
+                  coverImg: img
+                }
+                items.push(item)
+              }
+
+              // Create new chart
+              const newChart: StoredChart = {
+                timestamp: new Date().getTime(),
+                name: name,
+                data: {
+                  title: '',
+                  items: items,
+                  size: chartSize,
+                  background: {
+                    type: background.startsWith('#') ? BackgroundTypes.Color : BackgroundTypes.Image,
+                    value: background,
+                    img: backgroundImg
+                  },
+                  shadows: custom.shadowed,
+                  showNumbers: charts[prefix + 'numbered'] === 'true',
+                  showTitles: charts[prefix + 'titled'] === 'true',
+                  gap: custom.padding * 5,
+                  font: custom.fontFamily
+                },
+                currentlyActive: false
+              }
+
+              storedCharts.push(newChart)
+            } catch (e) {
+              console.error(e)
+              failed.push(name)
+            }
+          }
+
+          if (failed.length > 0) {
+            alert('Failed to import the following charts: ' + failed.join(', '))
+          } else {
+            alert('Charts imported successfully!')
+          }
+
+          setStoredCharts(storedCharts)
+          this.$store.commit('setEntireChart', storedCharts.filter((chart) => chart.currentlyActive)[0].data) // Force update, possibly a better way of doing this?
+        } catch (e) {
+          console.error(e)
+          alert('The file selected is not a valid Topsters 2 backup: ' + e)
+        }
+      })
+
+      fileReader.readAsText(files[0])
     }
   },
   computed: mapState({

--- a/src/components/Sidebar/Imports.vue
+++ b/src/components/Sidebar/Imports.vue
@@ -1,16 +1,170 @@
 <template>
   <div id="imports">
     <div class="container">
-      <h2>Coming soon!</h2>
+      <button
+        @click="importTopsters2Charts"
+      >
+        Import from Topsters 2
+      </button>
+      <input
+        type="file"
+        style="display: none"
+        ref="importTopsters2"
+        accept="application/json"
+        @change="importTopsters2ChartsPicked"/>
     </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from '@vue/runtime-core'
+import { getStoredCharts, setStoredCharts } from '../../helpers/localStorage'
+import { BackgroundTypes, StoredChart, ChartItem } from '@/types'
+import pako from 'pako'
 
 export default defineComponent({
+  methods: {
+    importTopsters2Charts () {
+      (this.$refs.importTopsters2 as HTMLFormElement).click()
+    },
+    importTopsters2ChartsPicked (event: Event) {
+      if (event.target === null) return
+      const files = (event.target as HTMLInputElement).files
+      if (files === null) return
+      const fileReader = new FileReader()
+      fileReader.addEventListener('load', () => {
+        try {
+          // Parse JSON file
+          const charts = JSON.parse(fileReader.result as string)[0]
+          const options = JSON.parse(charts.options)
 
+          // Import each chart
+          const textDecoder = new TextDecoder()
+          const storedCharts = getStoredCharts()
+          const failed = []
+          for (const chart of Object.entries(options.charts)) {
+            let prefix = chart[0] + '-'
+            if (prefix === 'cards-') prefix = ''
+            const name = chart[1] as string
+
+            try {
+              const custom = JSON.parse(charts[prefix + 'custom'])
+              const size = charts[prefix + 'size']
+              const chartSize = { x: 3, y: 3 }
+              switch (size) {
+                case '25': // Collage
+                  chartSize.x = custom.columns
+                  chartSize.y = custom.rows
+                  break
+                case '40': // Top 40
+                  chartSize.x = 5
+                  chartSize.y = 8
+                  break
+                case '42': // Top 42
+                  chartSize.x = 6
+                  chartSize.y = 7
+                  break
+                case '100': // Top 100
+                  chartSize.x = 10
+                  chartSize.y = 10
+                  break
+                default: // This should not happen, but set it to the max size just in case
+                  chartSize.x = 12
+                  chartSize.y = 12
+                  break
+              }
+
+              // Get background and parse if it's an image
+              let background = charts[prefix + 'background']
+              let backgroundImg = null
+              if (!background.startsWith('#')) {
+                try {
+                  // Parse URL
+                  const imgURL = background.match(/url\("(.+?)"\)/)
+                  if (imgURL === null) throw new Error()
+                  background = imgURL[1]
+                  backgroundImg = new Image()
+                  backgroundImg.src = background
+                } catch (e) {
+                  // Invalid URL format, set background color to black as fallback
+                  background = '#000000'
+                }
+              }
+
+              // Chart cards are compressed with zlib + encoded with base64
+              const chartCards = charts[prefix + 'cards'] // Get base64 string
+              const cardsCompressed = Uint8Array.from(atob(chartCards.substring(1, chartCards.length - 1)), c => c.charCodeAt(0)) // Convert base64 to bytes
+              const cardsDecompressed = textDecoder.decode(pako.inflate(cardsCompressed)) // Decompress and convert to text
+              const cards = JSON.parse(cardsDecompressed) // Parse cards
+
+              // Create chart items
+              const items: Array<ChartItem | null> = []
+              for (const card of cards) {
+                // Empty card
+                if (card.src === '') {
+                  items.push(null)
+                  continue
+                }
+
+                // Create item image
+                const img = new Image()
+                img.src = card.src
+
+                // Create item
+                const item: ChartItem = {
+                  title: card.title,
+                  coverURL: card.src,
+                  coverImg: img
+                }
+                items.push(item)
+              }
+
+              // Create new chart
+              const newChart: StoredChart = {
+                timestamp: new Date().getTime(),
+                name: name,
+                data: {
+                  title: '',
+                  items: items,
+                  size: chartSize,
+                  background: {
+                    type: background.startsWith('#') ? BackgroundTypes.Color : BackgroundTypes.Image,
+                    value: background,
+                    img: backgroundImg
+                  },
+                  shadows: custom.shadowed,
+                  showNumbers: charts[prefix + 'numbered'] === 'true',
+                  showTitles: charts[prefix + 'titled'] === 'true',
+                  gap: custom.padding * 5,
+                  font: custom.fontFamily
+                },
+                currentlyActive: false
+              }
+
+              storedCharts.push(newChart)
+            } catch (e) {
+              console.error(e)
+              failed.push(name)
+            }
+          }
+
+          if (failed.length > 0) {
+            alert('Failed to import the following charts: ' + failed.join(', '))
+          } else {
+            alert('Charts imported successfully!')
+          }
+
+          setStoredCharts(storedCharts)
+          this.$store.commit('setEntireChart', storedCharts.filter((chart) => chart.currentlyActive)[0].data) // Force update, possibly a better way of doing this?
+        } catch (e) {
+          console.error(e)
+          alert('The file selected is not a valid Topsters 2 backup: ' + e)
+        }
+      })
+
+      fileReader.readAsText(files[0])
+    }
+  }
 })
 </script>
 
@@ -28,11 +182,7 @@ export default defineComponent({
 
 .container {
   width: 100%;
-  margin: auto 10px;
-}
-
-h2 {
-  font-size: 1.2rem;
+  padding: 10px;
 }
 
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,6 +1159,11 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/pako@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-2.0.0.tgz#12ab4c19107528452e73ac99132c875ccd43bdfb"
+  integrity sha512-10+iaz93qR5WYxTo+PMifD5TSxiOtdRaxBf7INGGXMQgTCu8Z/7GYWYFUOS3q/G0nE5boj1r4FEB+WSy7s5gbA==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
@@ -7089,6 +7094,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+pako@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.4.tgz#6cebc4bbb0b6c73b0d5b8d7e8476e2b2fbea576d"
+  integrity sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg==
 
 pako@~1.0.5:
   version "1.0.11"


### PR DESCRIPTION
Adds a button to the top bar to import charts from a backup that was exported from [Topsters 2](https://www.neverendingchartrendering.org/).

This includes:
* Chart names
* Chart size (top 40/42/100 are set to 5x8, 6x7, and 10x10 collages respectively since Topsters 3 does not currently support Topsters 2's non-collage layouts)
* Album titles and covers (including images that were added by dragging and dropping an image in Topsters 2)
* Chart background (color/image)
* Other chart properties (font, padding, shadows, show/hide album titles and numbers, etc)