### PR TITLE
Add imports section

### DIFF
--- a/src/components/Sidebar/Imports.vue
+++ b/src/components/Sidebar/Imports.vue
@@ -1,0 +1,38 @@
+<template>
+  <div id="imports">
+    <div class="container">
+      <h2>Coming soon!</h2>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from '@vue/runtime-core'
+
+export default defineComponent({
+
+})
+</script>
+
+<style scoped>
+#imports {
+  display: flex;
+  background: #72bcd4;
+  margin-top: 0;
+  padding: 0;
+  border-radius: 0 0 5px 5px;
+  text-align: left;
+  overflow-y: scroll;
+  max-height: 500px;
+}
+
+.container {
+  width: 100%;
+  margin: auto 10px;
+}
+
+h2 {
+  font-size: 1.2rem;
+}
+
+</style>

--- a/src/components/Sidebar/index.vue
+++ b/src/components/Sidebar/index.vue
@@ -29,6 +29,18 @@
       <div>
         <button
           class="section-toggle"
+          :class="{ 'active-section-toggle': this.importsDisplayed }"
+          @click="this.importsDisplayed = !this.importsDisplayed"
+        >
+          <span>Imports</span>
+          <BIconCaretUpFill v-if="this.importsDisplayed" class="caret" />
+          <BIconCaretDownFill v-else class="caret" />
+        </button>
+        <Imports v-if="this.importsDisplayed" />
+      </div>
+      <div>
+        <button
+          class="section-toggle"
           :class="{ 'active-section-toggle': this.faqDisplayed }"
           @click="this.faqDisplayed = !this.faqDisplayed"
         >
@@ -64,6 +76,7 @@
 import Title from '../Title.vue'
 import SearchBox from './SearchBox/index.vue'
 import Options from './Options.vue'
+import Imports from './Imports.vue'
 import { defineComponent } from '@vue/runtime-core'
 import { BIconCaretDownFill, BIconCaretUpFill } from 'bootstrap-icons-vue'
 import FAQ from './FAQ.vue'
@@ -73,6 +86,7 @@ export default defineComponent({
     Title,
     SearchBox,
     Options,
+    Imports,
     FAQ,
     BIconCaretDownFill,
     BIconCaretUpFill
@@ -81,6 +95,7 @@ export default defineComponent({
     return {
       searchDisplayed: true,
       optionsDisplayed: false,
+      importsDisplayed: false,
       faqDisplayed: false
     }
   }


### PR DESCRIPTION
Adds a new section to the sidebar for import-related buttons. Currently empty, but will be used for imports from Topsters 2, Last.fm accounts, and whatever else in the future.