### PR TITLE
Migrate from Vuex to Pinia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "bootstrap-icons-vue": "^1.11.3",
-        "vue": "^3.5.3 ",
-        "vuex": "^4.1.0"
+        "pinia": "^2.2.2",
+        "vue": "^3.5.3 "
       },
       "devDependencies": {
         "@antfu/eslint-config": "^3.3.2",
@@ -1705,7 +1705,9 @@
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "6.5.1",
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.3.tgz",
+      "integrity": "sha512-0MiMsFma/HqA6g3KLKn+AGpL1kgKhFWszC9U29NfpWK5LE7bjeXxySWJrOJ77hBz+TBrBQ7o4QJqbPbqbs8rJw==",
       "license": "MIT"
     },
     "node_modules/@vue/language-core": {
@@ -4180,6 +4182,58 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pinia": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.2.2.tgz",
+      "integrity": "sha512-ja2XqFWZC36mupU4z1ZzxeTApV7DOw44cV4dhQ9sGwun+N89v/XP7+j7q6TanS1u1tdbK4r+1BUx7heMaIdagA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.0",
+        "typescript": ">=4.4.4",
+        "vue": "^2.6.14 || ^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pkg-types": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.0.tgz",
@@ -5196,16 +5250,6 @@
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"
-      }
-    },
-    "node_modules/vuex": {
-      "version": "4.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/devtools-api": "^6.0.0-beta.11"
-      },
-      "peerDependencies": {
-        "vue": "^3.2.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "bootstrap-icons-vue": "^1.11.3",
-    "vue": "^3.5.3 ",
-    "vuex": "^4.1.0"
+    "pinia": "^2.2.2",
+    "vue": "^3.5.3 "
   },
   "devDependencies": {
     "@antfu/eslint-config": "^3.3.2",

--- a/src/components/ChartBuilder/ChartCanvas.vue
+++ b/src/components/ChartBuilder/ChartCanvas.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import type { Ref } from 'vue'
 import generateChart from '../../chartgen'
 import { useStore } from '../../store'
@@ -20,9 +20,9 @@ const drawingCtx = computed(() => {
   return ctx
 })
 
-store.watch(state => state.chart, () => {
-  if (store.state.chart.background.type === 'image' && !store.state.chart.background.img.complete) {
-    store.state.chart.background.img.onload = () => {
+watch(() => store.chart, () => {
+  if (store.chart.background.type === 'image' && !store.chart.background.img.complete) {
+    store.chart.background.img.onload = () => {
       renderChart()
     }
   }
@@ -35,17 +35,17 @@ onMounted(() => {
     throw new Error('Couldn\'t find canvas. Something must have gone wrong with page loading, please refresh.')
   }
 
-  if (store.state.chart) {
-    if (store.state.chart.background.type === BackgroundTypes.Image) {
+  if (store.chart) {
+    if (store.chart.background.type === BackgroundTypes.Image) {
       const bgImg = new Image()
-      bgImg.src = store.state.chart.background.value
+      bgImg.src = store.chart.background.value
       bgImg.onload = () => {
         renderChart()
       }
-      store.state.chart.background.img = bgImg
+      store.chart.background.img = bgImg
     }
 
-    hydrateImages(store.state.chart)
+    hydrateImages(store.chart)
   }
 })
 
@@ -67,17 +67,17 @@ function renderChart() {
     return console.log('The canvas doesn\'nt exist! Maybe it tried to re-render after being unmounted.')
   }
 
-  hydrateImages(store.state.chart)
+  hydrateImages(store.chart)
 
   generateChart(
     canvas.value,
-    store.state.chart,
+    store.chart,
   )
 
   // Insert placeholders for empty squares
-  store.state.chart.items.slice(0, store.state.chart.size.x * store.state.chart.size.y).forEach((item, index) => {
+  store.chart.items.slice(0, store.chart.size.x * store.chart.size.y).forEach((item, index) => {
     if (!item) {
-      insertPlaceholder(drawingCtx.value, store.state.chart, index)
+      insertPlaceholder(drawingCtx.value, store.chart, index)
     }
   })
 }

--- a/src/components/ChartBuilder/Switcher.vue
+++ b/src/components/ChartBuilder/Switcher.vue
@@ -1,5 +1,5 @@
 <script setup lang='ts'>
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import type { Ref } from 'vue'
 import { addImgElements } from '../../helpers/chart'
 import { getActiveChartUuid, getStoredCharts, getUuids, setActiveChart } from '../../helpers/localStorage'
@@ -12,7 +12,7 @@ const activeChartUuid: Ref<string> = ref(getActiveChartUuid())
 const charts: Ref<StoredCharts> = ref(getStoredCharts())
 const chartUuids: Ref<string[]> = ref(getUuids())
 
-store.watch(state => state.chart, () => {
+watch(() => store.chart, () => {
   updateChartList()
 })
 
@@ -35,7 +35,7 @@ function changeChart(event: Event) {
 
   activeChartUuid.value = uuid
 
-  store.commit('setEntireChart', chartToSwitchTo)
+  store.setEntireChart(chartToSwitchTo)
 }
 </script>
 

--- a/src/components/ChartBuilder/TopBar.vue
+++ b/src/components/ChartBuilder/TopBar.vue
@@ -17,7 +17,7 @@ const loading: Ref<boolean> = ref(false)
 
 async function saveChart() {
   loading.value = true
-  await downloadChart(store.state.chart)
+  await downloadChart(store.chart)
   loading.value = false
 }
 
@@ -30,7 +30,7 @@ function startNewChart() {
   const newUuid = appendChart(newChart)
   setActiveChart(newUuid)
 
-  store.commit('reset')
+  store.reset()
 }
 
 function deleteChart() {
@@ -44,14 +44,14 @@ function deleteChart() {
     if (Object.keys(newStoredCharts).length < 1) {
       // We've just deleted the only saved chart, so let's re-initialize.
       initializeFirstRun()
-      store.commit('reset')
+      store.reset()
     }
     else {
       // If there are other charts, pick the most recently created one.
       const chart = setActiveChart(getNewestChartUuid())
 
       addImgElements(chart.data)
-      store.commit('setEntireChart', chart.data)
+      store.setEntireChart(chart.data)
     }
   }
 }

--- a/src/components/LocalStorageWatcher.vue
+++ b/src/components/LocalStorageWatcher.vue
@@ -19,38 +19,33 @@ onMounted(() => {
   const activeChart = getActiveChart()
 
   if (activeChart) {
-    store.commit('setEntireChart', activeChart.data)
+    store.setEntireChart(activeChart.data)
   }
   else {
     initializeFirstRun()
-    store.commit('setEntireChart', getActiveChart().data)
+    store.setEntireChart(getActiveChart().data)
   }
 })
 
-store.subscribe((mutation, state) => {
-  if (mutation.type === 'setEntireChart') {
-    store.commit('hydrateImages')
+store.$subscribe((mutation, state) => {
+  const activeChartUuid = getActiveChartUuid()
+  const activeChart = getActiveChart()
+
+  if (activeChart) {
+    const updatedChart = {
+      ...activeChart,
+      data: state.chart,
+    }
+
+    updateStoredChart(updatedChart, activeChartUuid)
   }
   else {
-    const activeChartUuid = getActiveChartUuid()
-    const activeChart = getActiveChart()
+    const newUuid = appendChart({
+      timestamp: new Date().getTime(),
+      data: state.chart,
+    })
 
-    if (activeChart) {
-      const updatedChart = {
-        ...activeChart,
-        data: state.chart,
-      }
-
-      updateStoredChart(updatedChart, activeChartUuid)
-    }
-    else {
-      const newUuid = appendChart({
-        timestamp: new Date().getTime(),
-        data: state.chart,
-      })
-
-      setActiveChart(newUuid)
-    }
+    setActiveChart(newUuid)
   }
 })
 </script>

--- a/src/components/Popup.vue
+++ b/src/components/Popup.vue
@@ -1,22 +1,24 @@
 <script setup lang="ts">
+import { watch } from 'vue'
 import { useStore } from '../store'
 
 const store = useStore()
 
-store.watch(state => state.popupText, () => {
+// todo: make sure this works
+watch(() => store.popupText, () => {
   // Make sure not to reset the popup when something else has been added.
-  const oldText = store.state.popupText
+  const oldText = store.popupText
   setTimeout(() => {
-    if (store.state.popupText === oldText) {
-      store.commit('setPopup', null)
+    if (store.popupText === oldText) {
+      store.setPopup(null)
     }
   }, 1500)
 })
 </script>
 
 <template>
-  <div v-if="store.state.popupText" id="popup">
-    <p>{{ store.state.popupText }}</p>
+  <div v-if="store.popupText" id="popup">
+    <p>{{ store.popupText }}</p>
   </div>
 </template>
 

--- a/src/components/Sidebar/Imports/LastFmImport.vue
+++ b/src/components/Sidebar/Imports/LastFmImport.vue
@@ -74,7 +74,7 @@ async function importLastFmChart() {
     }
   }
 
-  store.commit('setEntireChart', {
+  store.setEntireChart({
     ...initialState.chart,
     title: `${username}'s ${periodHeaders[period]} Chart`,
     items: newItems,

--- a/src/components/Sidebar/Imports/index.vue
+++ b/src/components/Sidebar/Imports/index.vue
@@ -11,10 +11,7 @@ import {
   importChart,
   importTopsters2,
 } from '../../../helpers/imports'
-import { useStore } from '../../../store'
 import LastFmImport from './LastFmImport.vue'
-
-const store = useStore()
 
 const topsters2ImportRef: Ref<HTMLInputElement> = ref(null)
 const uploadRef: Ref<HTMLInputElement> = ref(null)
@@ -30,11 +27,11 @@ function importTopsters2ChartsPicked(e) {
 }
 
 function importTopsters2Charts(event) {
-  importTopsters2(event, store)
+  importTopsters2(event)
 }
 
 async function callImportCharts(event) {
-  await importChart(event, store)
+  await importChart(event)
 }
 </script>
 

--- a/src/components/Sidebar/Options.vue
+++ b/src/components/Sidebar/Options.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue'
+import { onMounted, ref, watch } from 'vue'
 import type { Ref } from 'vue'
 import { useStore } from '../../store'
 import { BackgroundTypes } from '../../types'
@@ -10,7 +10,7 @@ const store = useStore()
 const gap: Ref<number> = ref(0)
 const backgroundType: Ref<BackgroundTypes> = ref(BackgroundTypes.Image)
 
-const chart: Ref<Chart> = ref(store.state.chart)
+const chart: Ref<Chart> = ref(store.chart)
 
 // Buckle up, here come the element refs 🤠
 const displayTitlesRef: Ref<HTMLFormElement> = ref(null)
@@ -26,8 +26,8 @@ const showNumbersRef: Ref<HTMLFormElement> = ref(null)
 const showShadowsRef: Ref<HTMLFormElement> = ref(null)
 const fontRef: Ref<HTMLFormElement> = ref(null)
 
-store.watch(state => state.chart, () => {
-  chart.value = store.state.chart
+watch(() => store.chart, () => {
+  chart.value = store.chart
   backgroundType.value = chart.value.background.type
   populateForm(chart.value)
 })
@@ -39,58 +39,58 @@ onMounted(() => {
 
 function updateTitle(event: Event): void {
   const title = (event.target as HTMLFormElement).value
-  return store.commit('changeTitle', title)
+  return store.changeTitle(title)
 }
 
 function updateBackgroundColor(event: Event): void {
   const color = (event.target as HTMLFormElement).value
-  return store.commit('changeBackgroundColor', color)
+  return store.changeBackgroundColor(color)
 }
 
 function updateSizeX(event: Event): void {
   const value = Number.parseInt((event.target as HTMLFormElement).value)
-  return store.commit('changeSize', { axis: 'x', value })
+  return store.changeSize({ axis: 'x', value })
 }
 
 function updateSizeY(event: Event): void {
   const value = Number.parseInt((event.target as HTMLFormElement).value)
-  return store.commit('changeSize', { axis: 'y', value })
+  return store.changeSize({ axis: 'y', value })
 }
 
 function updateGap(event: Event): void {
   const value = Number.parseInt((event.target as HTMLFormElement).value)
   gap.value = value
-  return store.commit('changeGap', value)
+  return store.changeGap(value)
 }
 
 function changeShowNumbers(event: Event): void {
   const value = (event.target as HTMLFormElement).checked
-  return store.commit('toggleNumbers', value)
+  return store.toggleNumbers(value)
 }
 
 function changeShowShadows(event: Event): void {
   const value = (event.target as HTMLFormElement).checked
-  return store.commit('toggleShadows', value)
+  return store.toggleShadows(value)
 }
 
 function updateFont(event: Event): void {
   const value = (event.target as HTMLFormElement).value
-  return store.commit('changeFont', value)
+  return store.changeFont(value)
 }
 
 function updateTextColor(event: Event): void {
   const value = (event.target as HTMLFormElement).value
-  return store.commit('changeTextColor', value)
+  return store.changeTextColor(value)
 }
 
 function changeShowTitles(event: Event): void {
   const value: boolean = (event.target as HTMLFormElement).checked
-  return store.commit('toggleTitles', value)
+  return store.toggleTitles(value)
 }
 
 function initalSetup(): void {
-  if (store.state.chart) {
-    populateForm(store.state.chart)
+  if (store.chart) {
+    populateForm(store.chart)
   }
 }
 
@@ -132,7 +132,7 @@ function changeBackgroundType(event: Event): void {
 
 function updateBackgroundImage(event: Event): void {
   const url = ((event.target as HTMLFormElement).value)
-  store.commit('setBackgroundImage', url)
+  store.setBackgroundImage(url)
 }
 </script>
 

--- a/src/components/Sidebar/SearchBox/SearchDropdown.vue
+++ b/src/components/Sidebar/SearchBox/SearchDropdown.vue
@@ -60,15 +60,15 @@ function filterTV(results: TVResult[]): TVResult[] {
 
 function addToChart(item: Result): void {
   // Get the index of the first null chart slot
-  const firstEmptyIndex = store.state.chart.items.indexOf(null)
+  const firstEmptyIndex = store.chart.items.indexOf(null)
 
-  const totalSlots = store.state.chart.size.x * store.state.chart.size.y
+  const totalSlots = store.chart.size.x * store.chart.size.y
 
   // Only add an item if there's a visible slot
   if (firstEmptyIndex < totalSlots) {
     const newItem = createChartItem(item)
-    store.commit('addItem', { item: newItem, index: firstEmptyIndex })
-    store.commit('setPopup', `Added ${newItem.title}`)
+    store.addItem({ item: newItem, index: firstEmptyIndex })
+    store.setPopup(`Added ${newItem.title}`)
   }
 }
 

--- a/src/components/buttons/Download.vue
+++ b/src/components/buttons/Download.vue
@@ -11,7 +11,7 @@ const store = useStore()
 async function saveChart() {
   loading.value = true
 
-  await downloadChart(store.state.chart)
+  await downloadChart(store.chart)
 
   loading.value = false
 }

--- a/src/helpers/chart.ts
+++ b/src/helpers/chart.ts
@@ -1,9 +1,9 @@
 // Functions for filling in the chart.
 
-import type { Store } from 'vuex'
+import { Store } from 'pinia'
 import fetchImageURL from '../api/fetchImage'
 import generateChart from '../chartgen'
-import { initialState } from '../store'
+import { initialState, useStore } from '../store'
 import {
   BackgroundTypes,
   type Chart,
@@ -204,9 +204,11 @@ export function createNewChart() {
 // Forces the chart to re-render from localStorage.
 // Useful in situations where we update the charts by
 // modifying localStorage directly such as imports.
-export function forceRefresh(store: Store<State>) {
+export function forceRefresh() {
+  const store = useStore()
+
   const activeChart = getActiveChart()
-  store.commit('setEntireChart', activeChart.data)
+  store.setEntireChart(activeChart.data)
 }
 
 export const periodHeaders = {

--- a/src/helpers/imports.ts
+++ b/src/helpers/imports.ts
@@ -2,11 +2,9 @@
 
 // Functions related to importing and exporting charts
 
-import type { Store } from 'vuex'
 import { BackgroundTypes } from '../types'
 import { forceRefresh } from './chart'
 import { appendChart, findByUuid, getActiveChart, getActiveChartUuid, getNewestChartUuid, setActiveChart, updateStoredChart } from './localStorage'
-import type { State } from '../store'
 import type { ChartItem, StoredChart, StoredCharts } from '../types'
 
 async function unzlib(data: Uint8Array) {
@@ -64,7 +62,7 @@ export async function parseUploadedText(text: string) {
   return decoded
 }
 
-export async function importChart(event: Event, store: Store<State>) {
+export async function importChart(event: Event) {
   const files = (event.target as HTMLInputElement).files
 
   try {
@@ -83,14 +81,14 @@ export async function importChart(event: Event, store: Store<State>) {
         overwriteConsent = true
         updateStoredChart(newChart, newChartUuid)
         setActiveChart(newChartUuid)
-        forceRefresh(store)
+        forceRefresh()
       }
     }
     else {
       overwriteConsent = true
       appendChart(newChart, newChartUuid)
       setActiveChart(newChartUuid)
-      forceRefresh(store)
+      forceRefresh()
     }
 
     if (overwriteConsent) {
@@ -103,7 +101,7 @@ export async function importChart(event: Event, store: Store<State>) {
   }
 }
 
-export async function importTopsters2(event: Event, store: Store<State>) {
+export async function importTopsters2(event: Event) {
   if (event.target === null)
     return
   const files = (event.target as HTMLInputElement).files
@@ -251,7 +249,7 @@ export async function importTopsters2(event: Event, store: Store<State>) {
 
       // Set the newly imported chart to currently active
       setActiveChart(getNewestChartUuid())
-      forceRefresh(store)
+      forceRefresh()
     }
     catch (e) {
       console.error(e)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,9 @@
+import { createPinia } from 'pinia'
 import { createApp } from 'vue'
 import App from './App.vue'
-import { key, store } from './store'
+
+const pinia = createPinia()
 
 createApp(App)
-  .use(store, key)
+  .use(pinia)
   .mount('#app')


### PR DESCRIPTION
This PR migrates the store from Vuex to Pinia, which is the newer replacement for Vuex.

The migration was a lot more straightforward than I expected because Topsters 3's Vuex state was simpler than the example store in the Pinia migration guide. I think this PR is complete and I've done most of the testing I can think of (all options, downloading, import/export, mobile toast notifications). But I've been on a bit of a personal hackathon today so I want to let this sit and maybe test it some more on another day before merging.

Closes #41 