### PR TITLE
fix dnd dom leak + misc cleanup

### DIFF
--- a/src/components/ChartBuilder/Chart/Item.vue
+++ b/src/components/ChartBuilder/Chart/Item.vue
@@ -34,14 +34,17 @@ function handleDragStart(ev: DragEvent) {
 
     // match the item's scale to the chart
     const chart = document.getElementById('chart')
-    const chartTransform = chart.style.transform
-    const scaleRatio = chartTransform.slice(6, chartTransform.length - 1)
-    const scaledSize = 260 * Number.parseFloat(scaleRatio)
+    const scaleMatch = chart?.style.transform?.match(/scale\(([^)]+)\)/)
+    const scaleRatio = scaleMatch ? Number.parseFloat(scaleMatch[1]) : 1
+    const scaledSize = 260 * scaleRatio
     container.style.height = `${scaledSize}px`
     container.style.width = `${scaledSize}px`
 
     const appEl = document.querySelector('#app')
-    appEl.appendChild(container)
+    appEl?.appendChild(container)
+
+    // clean up the drag image element after the drag ends
+    ev.target?.addEventListener('dragend', () => container.remove(), { once: true })
 
     ev.dataTransfer.effectAllowed = 'move'
     ev.dataTransfer.setData('application/json', dragData)

--- a/src/components/ChartBuilder/Chart/index.vue
+++ b/src/components/ChartBuilder/Chart/index.vue
@@ -75,11 +75,11 @@ const chartStyle: ComputedRef<CSSProperties> = computed(() => ({
 }))
 
 onMounted(() => {
-  window.onresize = onResize
+  window.addEventListener('resize', onResize)
 })
 
 onUnmounted(() => {
-  window.onresize = undefined
+  window.removeEventListener('resize', onResize)
 })
 </script>
 

--- a/src/components/ChartBuilder/Switcher.vue
+++ b/src/components/ChartBuilder/Switcher.vue
@@ -44,8 +44,8 @@ function changeChart(event: Event) {
       @change="changeChart"
     >
       <option
-        v-for="(uuid, index) in chartUuids"
-        :key="index"
+        v-for="uuid in chartUuids"
+        :key="uuid"
         :value="uuid"
         :selected="uuid === activeChartUuid"
       >

--- a/src/components/Sidebar/Options/index.vue
+++ b/src/components/Sidebar/Options/index.vue
@@ -50,7 +50,7 @@ const storeRef = storeToRefs(store)
     <SelectInput
       label="Background Type"
       property="backgroundType"
-      :options="['color', 'image']"
+      :options="Object.values(BackgroundTypes)"
       :value="storeRef.chart.value.backgroundType"
       @handle-change="store.setBackgroundType"
     />

--- a/src/helpers/typeGuards.ts
+++ b/src/helpers/typeGuards.ts
@@ -37,7 +37,7 @@ export function isMovieResult(item: Result): item is MovieResult {
 }
 
 export function isTVResult(item: Result): item is TVResult {
-  if ((item as TVResult).name && (item as MovieResult).poster_path) {
+  if ((item as TVResult).name && (item as TVResult).poster_path) {
     return true
   }
   else {


### PR DESCRIPTION
drag images were getting appended to #app on every drag and never removed, so they'd pile up. added a dragend listener to clean them up.

also:
- null safety for getElementById/querySelector in the drag handler
- regex instead of brittle slice() for parsing the chart scale transform
- addEventListener instead of overwriting window.onresize
- use uuid as v-for key in switcher instead of index
- use BackgroundTypes enum instead of hardcoded strings
- fix isTVResult casting to MovieResult instead of TVResult