### PR TITLE
Use HTTPS for github dependencies instead of SSH

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,7 @@ jobs:
           VITE_BACKEND_URL: ${{ secrets.VITE_BACKEND_URL }}
           VITE_GOOGLE_ANALYTICS_TAG: ${{ secrets.VITE_GOOGLE_ANALYTICS_TAG }}
         run: |
+          git config --global url."https://github.com/".insteadOf ssh://git@github.com/
           npm ci
           npm run build
       - name: Deploy


### PR DESCRIPTION
This PR should greatly speed up the GitHub Actions pipeline because installing the `html2canvas-smart-cors` package seems to take 5+ minutes. I will merge when I have time to test it.